### PR TITLE
Add support for a shared directory 

### DIFF
--- a/files/usr/bin/container-start.sh
+++ b/files/usr/bin/container-start.sh
@@ -103,7 +103,7 @@ CID_ON_START=$(docker run -d $OVERRIDE_ENTRYPOINT  \
        --cap-add NET_ADMIN \
        --cap-add NET_RAW \
        -v $BASEDIR/$SCHEDID.conf:/monroe/config:ro \
-       -v /etc/nodeid:/nodeid:ro \ \
+       -v /etc/nodeid:/nodeid:ro \
        -v $READONLYDIR:/monroe/shared:ro \
        $MOUNT_DISK \
        $TSTAT_DISK \

--- a/files/usr/bin/container-start.sh
+++ b/files/usr/bin/container-start.sh
@@ -6,8 +6,10 @@ STATUS=$2
 CONTAINER=monroe-$SCHEDID
 
 BASEDIR=/experiments/user
+READONLYDIR=/experiments/shared-readonly
 STATUSDIR=$BASEDIR
 mkdir -p $BASEDIR
+mkdir -p $READONLYDIR
 
 if [ -f $BASEDIR/$SCHEDID.conf ]; then
   CONFIG=$(cat $BASEDIR/$SCHEDID.conf);
@@ -101,7 +103,8 @@ CID_ON_START=$(docker run -d $OVERRIDE_ENTRYPOINT  \
        --cap-add NET_ADMIN \
        --cap-add NET_RAW \
        -v $BASEDIR/$SCHEDID.conf:/monroe/config:ro \
-       -v /etc/nodeid:/nodeid:ro \
+       -v /etc/nodeid:/nodeid:ro \ \
+       -v $READONLYDIR:/monroe/shared:ro \
        $MOUNT_DISK \
        $TSTAT_DISK \
        $CONTAINER $OVERRIDE_PARAMETERS)


### PR DESCRIPTION
Things to consider: should the mountpoint be /experiments/shared-readonly or rather /mnt/shared-readonly or similar. 