### PR TITLE
Create the container subdirectory

### DIFF
--- a/files/usr/bin/container-start.sh
+++ b/files/usr/bin/container-start.sh
@@ -22,6 +22,7 @@ if [ ! -z "$IS_INTERNAL" ]; then
   # redirect output to log file
   exec > $BASEDIR/start.log 2>&1
 else
+  mkdir -p $BASEDIR/$SCHEDID
   exec >> $BASEDIR/$SCHEDID/start.log 2>&1
 fi
 


### PR DESCRIPTION
It seems the /experiments/user/expdir was not created, so the redirect to the start.log file would fail, as well as the mounting of the disk image.