### PR TITLE
jq does not extract eduroam username

### DIFF
--- a/files/usr/bin/container-start.sh
+++ b/files/usr/bin/container-start.sh
@@ -14,8 +14,8 @@ if [ -f $BASEDIR/$SCHEDID.conf ]; then
   IS_INTERNAL=$(echo $CONFIG | jq -r '.internal // empty');
   IS_SSH=$(echo $CONFIG | jq -r '.ssh // empty');
   BDEXT=$(echo $CONFIG | jq -r '.basedir // empty');
-  EDUROAM_IDENTITY=$(echo $CONFIG | jq -r '.eduroam.identity // empty');
-  EDUROAM_HASH=$(echo $CONFIG | jq -r '._eduroam.hash // empty');
+  EDUROAM_IDENTITY=$(echo $CONFIG | jq -r '.["eduroam.identity"] // empty');
+  EDUROAM_HASH=$(echo $CONFIG | jq -r '.["_eduroam.hash"] // empty');
 fi
 if [ ! -z "$IS_INTERNAL" ]; then
   BASEDIR=/experiments/monroe${BDEXT}


### PR DESCRIPTION
The jq filter does not extract fields with dots. Needs [" "] as below: 
```
root@Monroe000:~# cat /tmp/config | jq -r '.eduroam.identity // empty'
root@Monroe000:~# cat /tmp/config | jq -r '.["eduroam.identity"] // empty'
stefalfr01@student.kau.se
root@Monroe000:~#
```