### PR TITLE
Fxed a bug where .status where removed

### DIFF
--- a/files/usr/bin/container-stop.sh
+++ b/files/usr/bin/container-stop.sh
@@ -164,9 +164,12 @@ echo -n "Cleaning files... "
 
 umount $BASEDIR/$SCHEDID
 rmdir  $BASEDIR/$SCHEDID
+# .traffic and .status should be kept (are deleted by external scripts after read)
 mv     $STATUSDIR/${SCHEDID}.traffic  $STATUSDIR/${SCHEDID}-traffic
+mv     $STATUSDIR/${SCHEDID}.status  $STATUSDIR/${SCHEDID}-status
 rm -rf $BASEDIR/${SCHEDID}.*
 mv     $STATUSDIR/${SCHEDID}-traffic  $STATUSDIR/${SCHEDID}.traffic_
+mv     $STATUSDIR/${SCHEDID}-status  $STATUSDIR/${SCHEDID}.status
 rm -r  $USAGEDIR/monroe-${SCHEDID}
 echo "ok."
 


### PR DESCRIPTION
The $schedid.status is read (and removed) by marvind after the status is transmitted to the server.