### PR TITLE
Stop unwanted tasks before experiment start

### DIFF
--- a/files/usr/bin/container-start.sh
+++ b/files/usr/bin/container-start.sh
@@ -6,6 +6,7 @@ set -e
 SCHEDID=$1
 STATUS=$2
 CONTAINER=monroe-$SCHEDID
+UNWANTED_TASKS_AT_EXPERIMENT_START=("docker pull" "rsync" "ansible" "ansible-wrapper" "apt" "scp")
 
 BASEDIR=/experiments/user
 STATUSDIR=$BASEDIR
@@ -204,6 +205,13 @@ if [ ! -z "$NEAT_PROXY"  ]; then
     fi
    done
 fi
+
+### Stop tasks that can influence experiment results #####################
+echo "Stopping unwanted tasks/processes before starting experiment..."
+for task in "${UNWANTED_TASKS_AT_EXPERIMENT_START[@]}"; do
+   echo -n "$task: "
+   pkill -9 -f "$task" && echo "stopped" || echo "not running"
+done
 
 # drop all network traffic for 30 seconds (idle period)
 nohup /bin/bash -c 'sleep 35; circle start' > /dev/null &

--- a/files/usr/bin/container-start.sh
+++ b/files/usr/bin/container-start.sh
@@ -210,7 +210,16 @@ fi
 echo "Stopping unwanted tasks/processes before starting experiment..."
 for task in "${UNWANTED_TASKS_AT_EXPERIMENT_START[@]}"; do
    echo -n "$task: "
-   pkill -9 -f "$task" && echo "stopped" || echo "not running"
+   _PIDS=$(pgrep -f "$task")
+   if [ -z "$_PIDS" ]; then
+        echo -n "not running"
+   else
+        echo -n "killing :"
+   fi
+   for _pid in $_PIDS; do
+        /sbin/start-stop-daemon --stop --signal TERM --retry 30 --oknodo --pid $_pid && echo -n " $_pid"
+   done
+   echo ""
 done
 
 # drop all network traffic for 30 seconds (idle period)


### PR DESCRIPTION
UNWANTED_TASKS_AT_EXPERIMENT_START   defines what tasks/processes should be stopped before a experiment is started : 

Solves dangling processes/tasks in https://github.com/kaucs/MONROE-Maintenance-internal/issues/33
Do not solve unknown processes that use cpu/bandwith or processes that automatically restarts

Backport from https://github.com/MONROE-PROJECT/monroe-experiment-core/commit/9578cd98c0a6ff4b0334dd8f369e6caf2bb06a05