### PR TITLE
Response type cannot be empty string

### DIFF
--- a/marvin/restapi.py
+++ b/marvin/restapi.py
@@ -109,7 +109,7 @@ class Resource:
 
         if role == scheduler.ROLE_NODE:
             if name != ("Node %s" % nodeid):
-                web.ctx.status = ''
+                web.ctx.status = '401 Unauthorized'
                 return error("Wrong user to update this status. (%s)" % name)
             now = int(time.time())
             maintenance = data.get('maintenance',0)


### PR DESCRIPTION
The return type cannot be a empty string or the lib will crash with a conversion to int failure. 